### PR TITLE
Support flake inputs with type path

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -36,6 +36,10 @@ let
         lastModifiedDate = formatSecondsSinceEpoch info.lastModified;
         narHash = info.narHash;
       }
+    else if info.type == "path" then
+      { outPath = builtins.path { path = info.path; };
+        narHash = info.narHash;
+      }
     else
       # FIXME: add Mercurial, tarball inputs.
       throw "flake input has unsupported input type '${info.type}'";


### PR DESCRIPTION
I figured I should copy it into the store with `builtins.path`, since the others use `builtins.fetchGit`/`fetchTarball` which adds to the store. But it seems like `outPath = info.path;` works as well (probably not when enforcing purity though).