### PR TITLE
Support flake inputs with type tarball

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -40,6 +40,10 @@ let
       { outPath = builtins.path { path = info.path; };
         narHash = info.narHash;
       }
+    else if info.type == "tarball" then
+      { outPath = fetchTarball info.url;
+        narHash = info.narHash;
+      }
     else
       # FIXME: add Mercurial, tarball inputs.
       throw "flake input has unsupported input type '${info.type}'";


### PR DESCRIPTION
I've noticed that I could do something like this :smile: 

```$ nix flake update --override-input nixpkgs https://releases.nixos.org/nixos/20.03/nixos-20.03.2802.f8a10a77193/nixexprs.tar.xz```

Thought it would be nice to have support for non-flake `nix` :wink: 