### PR TITLE
Be more consistent with Nix itself when fetching github/gitlab inputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ let
   fetchTree =
     info:
     if info.type == "github" then
-      { outPath = fetchTarball "https://api.${info.url or "github.com"}/repos/${info.owner}/${info.repo}/tarball/${info.rev}";
+      { outPath = fetchTarball "https://api.${info.host or "github.com"}/repos/${info.owner}/${info.repo}/tarball/${info.rev}";
         rev = info.rev;
         shortRev = builtins.substring 0 7 info.rev;
         lastModified = info.lastModified;
@@ -46,7 +46,7 @@ let
       }
     else if info.type == "gitlab" then
       { inherit (info) rev narHash lastModified;
-        outPath = fetchTarball "https://${info.url or "gitlab.com"}/${info.owner}/${info.repo}/-/archive/${info.rev}/${info.repo}-${info.rev}.tar.gz";
+        outPath = fetchTarball "https://${info.host or "gitlab.com"}/api/v4/projects/${info.owner}%2F${info.repo}/repository/archive.tar.gz?sha=${info.rev}";
         shortRev = builtins.substring 0 7 info.rev;
       }
     else


### PR DESCRIPTION
* `url` got renamed to `host` in Nix[1], so we have to use this key here
  as well.
* It was suggested previously[2] to use the same URL to download from a
  GitLab-server as Nix does.

[1] https://github.com/NixOS/nix/commit/56f1e0df0546c744421c7d1bd31b1a341796513c
[2] https://github.com/edolstra/flake-compat/commit/0e29814f1ef3b48e89cd2c9998a97e917beb7ea9#commitcomment-42619895