### PR TITLE
Make tarball fetchers pure

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,11 @@ let
   fetchTree =
     info:
     if info.type == "github" then
-      { outPath = fetchTarball "https://api.${info.host or "github.com"}/repos/${info.owner}/${info.repo}/tarball/${info.rev}";
+      { outPath =
+          fetchTarball
+            ({ url = "https://api.${info.host or "github.com"}/repos/${info.owner}/${info.repo}/tarball/${info.rev}"; }
+             // (if info ? narHash then { sha256 = info.narHash; } else {})
+            );
         rev = info.rev;
         shortRev = builtins.substring 0 7 info.rev;
         lastModified = info.lastModified;
@@ -41,12 +45,19 @@ let
         narHash = info.narHash;
       }
     else if info.type == "tarball" then
-      { outPath = fetchTarball info.url;
-        narHash = info.narHash;
+      { outPath =
+          fetchTarball
+            ({ inherit (info) url; }
+             // (if info ? narHash then { sha256 = info.narHash; } else {})
+            );
       }
     else if info.type == "gitlab" then
       { inherit (info) rev narHash lastModified;
-        outPath = fetchTarball "https://${info.host or "gitlab.com"}/api/v4/projects/${info.owner}%2F${info.repo}/repository/archive.tar.gz?sha=${info.rev}";
+        outPath =
+          fetchTarball
+            ({ url = "https://${info.host or "gitlab.com"}/api/v4/projects/${info.owner}%2F${info.repo}/repository/archive.tar.gz?sha=${info.rev}"; }
+             // (if info ? narHash then { sha256 = info.narHash; } else {})
+            );
         shortRev = builtins.substring 0 7 info.rev;
       }
     else


### PR DESCRIPTION
 - Allows flake-compat to be used in pure mode in some cases.
 - Prevents periodic refetching of the same tarballs. (with https://github.com/NixOS/nix/issues/4313)

The conditionals should preserve the old behavior for impure fetching.