### PR TITLE
Allow use on repos without commits

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -77,12 +77,14 @@ let
     # Try to clean the source tree by using fetchGit, if this source
     # tree is a valid git repository.
     tryFetchGit = src:
-      if isGit && !isShallow
+      if isGit && !isShallow && hasBranch
       then builtins.fetchGit src
       else { outPath = src; };
     # NB git worktrees have a file for .git, so we don't check the type of .git
     isGit = builtins.pathExists (src + "/.git");
     isShallow = builtins.pathExists (src + "/.git/shallow");
+    # Repos without commits do not have any heads.
+    hasBranch = builtins.pathExists (src + "/.git/refs/heads") && builtins.readDir (src + "/.git/refs/heads") != { };
 
   in
     (if src ? outPath then src else tryFetchGit src)


### PR DESCRIPTION
When starting a new repository, it does not have any branches in `.git/refs/heads` and `.git/refs/HEAD` contains a broken `ref: refs/heads/master` reference.

This means that cloning a repo like we do for cleaning will fail with very unhelpful message for freshly created repo:

    fatal: bad revision 'HEAD'

This is quite confusing when you create a new repo by copying Nix files from another, working one, make some trivial changes, stage them and then try to test a shell.
