### PR TITLE
Add support for "path:./relative/path"

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -39,7 +39,10 @@ let
       } else {
       })
     else if info.type == "path" then
-      { outPath = builtins.path { path = info.path; };
+      { outPath = builtins.path {
+          path = if builtins.substring 0 2 info.path == "./"
+            then src + builtins.substring 1 (-1) info.path
+            else info.path; };
         narHash = info.narHash;
       }
     else if info.type == "tarball" then


### PR DESCRIPTION
My system config flake uses `inputs.private.url = "path:./private";` for information that is ok to be in the store but shouldn't be on Github. This is a git submodule so a relative path feels like the right way to refer to it.

Without this patch, flake-compat wants an absolute path:

```
# nix --version
nix (Nix) 2.4pre20201201_5a6ddb3

# nix-build '<nixpkgs/nixos>' -A system
warning: Git tree '/etc/nixos' is dirty
error: --- EvalError ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- nix-build
at: (42:35) in file: /nix/store/2mpgi4bvn8py4liv9w3mjxd2c5r7bvv8-source/default.nix

    41|     else if info.type == "path" then
    42|       { outPath = builtins.path { path = info.path; };
      |                                   ^
    43|         narHash = info.narHash;

string './private' doesn't represent an absolute path
(use '--show-trace' to show detailed location information)
```