### PR TITLE
Add MIT license

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,20 @@
+Copyright (c) 2020-2021 Eelco Dolstra and the flake-compat contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/default.nix
+++ b/default.nix
@@ -46,13 +46,6 @@ let
       { outPath = builtins.path { path = info.path; };
         narHash = info.narHash;
       }
-    else if info.type == "tarball" then
-      { outPath =
-          fetchTarball
-            ({ inherit (info) url; }
-             // (if info ? narHash then { sha256 = info.narHash; } else {})
-            );
-      }
     else if info.type == "gitlab" then
       { inherit (info) rev narHash lastModified;
         outPath =


### PR DESCRIPTION
An open source license protects contributors and users. Closes #16.

I assume the omission of a license was an oversight, so I would like to help by providing a suggestion and taking care of the process.

For the license I propose MIT, same as Nixpkgs.

@edolstra @Ma27 @zanculmarktum @cole-h @matthewbauer @nlewo @zimbatm please comment to confirm:

I agree to license my contributions to flake-compat under the terms of the MIT license.

------

Of course you are free not to agree. Doing so would be bad for the community though. See https://choosealicense.com/no-permission/

cc issue respondents @alyssais @clayrisser @pombredanne @zhaofengli
