### PR TITLE
return result of all packages

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -194,4 +194,6 @@ in
     shellNix =
       defaultNix
       // (if result ? devShell.${system} then { default = result.devShell.${system}; } else {});
+
+    inherit result;
   }


### PR DESCRIPTION
in a flake I work on, I need to provide a compatibility layer for other packages than the default one, exposing result gives me the possibility. I dont mind if this gets closed, just wanted to share the possibility.

With this PR, one can  use the following shell.nix to reference a specific package
```
{ system ? builtins.currentSystem or "unknown-system" }:

(import (
let
    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
  in fetchTarball {
    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
    sha256 = lock.nodes.flake-compat.locked.narHash; }
) {
  src =  ./.;
}).result.packages.${system}.ci
