### PR TITLE
Link to wiki to explain flake-compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # flake-compat
 
+## Introduction
+
+**[Nix Flakes: Using flakes project from a legacy Nix.](https://nixos.wiki/wiki/Flakes#Using_flakes_project_from_a_legacy_Nix)**
+
 ## Usage
 
 To use, add the following to your `flake.nix`:


### PR DESCRIPTION
It's confusing as a newbie to arrive at this repo and have no context whatsoever. Instead, we link to the nix wiki instead to point people to an explanation.