### PR TITLE
Support fetching file type flakes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,9 +17,10 @@ let
   # The hash we get from the lock file is using recursive ingestion even though
   # it’s not unpacked. So builtins.fetchurl and import <nix/fetchurl.nix> are
   # insufficient.
+  # Note that this will be a derivation and not a path as fetchTarball is,
+  # causing the hash of this input to be different on flake and non-flake evaluation.
   fetchurl = { url, sha256 }:
-    # need to hide the fact it’s a derivation so that the output is just a path
-    builtins.storePath (builtins.unsafeDiscardStringContext (derivation {
+    derivation {
       builder = "builtin:fetchurl";
 
       name = "source";
@@ -46,7 +47,7 @@ let
 
       # To make "nix-prefetch-url" work.
       urls = [ url ];
-    }).outPath);
+    };
 
   fetchTree =
     info:

--- a/default.nix
+++ b/default.nix
@@ -78,7 +78,10 @@ let
       } else {
       })
     else if info.type == "path" then
-      { outPath = builtins.path { path = info.path; };
+      { outPath = builtins.path
+          ({ path = info.path; }
+           // (if info ? narHash then { sha256 = info.narHash; } else {})
+          );
         narHash = info.narHash;
       }
     else if info.type == "tarball" then
@@ -105,9 +108,13 @@ let
           if builtins.substring 0 7 info.url == "http://" || builtins.substring 0 8 info.url == "https://" then
             fetchurl
               ({ inherit (info) url; }
-               // (if info ? narHash then { sha256 = info.narHash; } else {}))
+               // (if info ? narHash then { sha256 = info.narHash; } else {})
+              )
           else if builtins.substring 0 7 info.url == "file://" then
-            builtins.path { path = builtins.substring 7 (-1) info.url; }
+            builtins.path
+              ({ path = builtins.substring 7 (-1) info.url; }
+               // (if info ? narHash then { sha256 = info.narHash; } else {})
+              )
           else throw "can't support url scheme of flake input with url '${info.url}'";
         narHash = info.narHash;
       }


### PR DESCRIPTION
Add supports for new type = "file" locks added in
https://github.com/NixOS/nix/commit/5b8c1deb18e0e6fc7a83fb8101cf5fc8dba38843.

Unfortunately, the hash provided by the lock file is a recursive hash,
while fetchurl wants a flat hash. So we have to use a custom fetchurl
function using the builtin:fetchurl builder. Hopefully okay just to
add compat for this very useful lock type.

cc @edolstra 

Fixes #44.