### PR TITLE
Introduce a new `overrideInputs` on {default,shell}Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Afterwards, create a `default.nix` file containing the following:
   (
     let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
     fetchTarball {
-      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      url = with lock.nodes.flake-compat.locked;
+        "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
       sha256 = lock.nodes.flake-compat.locked.narHash;
     }
   )

--- a/default.nix
+++ b/default.nix
@@ -8,193 +8,221 @@
 { src, system ? builtins.currentSystem or "unknown-system" }:
 
 let
+  id = x: x;
+  overrideWrap' = fn: set: set // { overrideInputs = ov: fn (makeFlakeCompat ov); };
+  overrideWrap = overrideWrap' id;
+  makeFlakeCompat = impureOverrides:
+  let
+    lockFilePath = src + "/flake.lock";
 
-  lockFilePath = src + "/flake.lock";
+    lockFile = builtins.fromJSON (builtins.readFile lockFilePath);
 
-  lockFile = builtins.fromJSON (builtins.readFile lockFilePath);
+    fetchTree =
+      info:
+      if info.type == "github" then
+        { outPath =
+            fetchTarball
+              ({ url = "https://api.${info.host or "github.com"}/repos/${info.owner}/${info.repo}/tarball/${info.rev}"; }
+              // (if info ? narHash then { sha256 = info.narHash; } else {})
+              );
+          rev = info.rev;
+          shortRev = builtins.substring 0 7 info.rev;
+          lastModified = info.lastModified;
+          lastModifiedDate = formatSecondsSinceEpoch info.lastModified;
+          narHash = info.narHash;
+        }
+      else if info.type == "git" then
+        { outPath =
+            builtins.fetchGit
+              ({ url = info.url; }
+              // (if info ? rev then { inherit (info) rev; } else {})
+              // (if info ? ref then { inherit (info) ref; } else {})
+              // (if info ? submodules then { inherit (info) submodules; } else {})
+              );
+          lastModified = info.lastModified;
+          lastModifiedDate = formatSecondsSinceEpoch info.lastModified;
+          narHash = info.narHash;
+        } // (if info ? rev then {
+          rev = info.rev;
+          shortRev = builtins.substring 0 7 info.rev;
+        } else {
+        })
+      else if info.type == "path" then
+        { outPath = builtins.path { path = info.path; };
+          narHash = info.narHash;
+        }
+      else if info.type == "tarball" then
+        { outPath =
+            fetchTarball
+              ({ inherit (info) url; }
+              // (if info ? narHash then { sha256 = info.narHash; } else {})
+              );
+        }
+      else if info.type == "gitlab" then
+        { inherit (info) rev narHash lastModified;
+          outPath =
+            fetchTarball
+              ({ url = "https://${info.host or "gitlab.com"}/api/v4/projects/${info.owner}%2F${info.repo}/repository/archive.tar.gz?sha=${info.rev}"; }
+              // (if info ? narHash then { sha256 = info.narHash; } else {})
+              );
+          shortRev = builtins.substring 0 7 info.rev;
+        }
+      else
+        # FIXME: add Mercurial, tarball inputs.
+        throw "flake input has unsupported input type '${info.type}'";
 
-  fetchTree =
-    info:
-    if info.type == "github" then
-      { outPath =
-          fetchTarball
-            ({ url = "https://api.${info.host or "github.com"}/repos/${info.owner}/${info.repo}/tarball/${info.rev}"; }
-             // (if info ? narHash then { sha256 = info.narHash; } else {})
-            );
-        rev = info.rev;
-        shortRev = builtins.substring 0 7 info.rev;
-        lastModified = info.lastModified;
-        lastModifiedDate = formatSecondsSinceEpoch info.lastModified;
-        narHash = info.narHash;
-      }
-    else if info.type == "git" then
-      { outPath =
-          builtins.fetchGit
-            ({ url = info.url; }
-             // (if info ? rev then { inherit (info) rev; } else {})
-             // (if info ? ref then { inherit (info) ref; } else {})
-             // (if info ? submodules then { inherit (info) submodules; } else {})
-            );
-        lastModified = info.lastModified;
-        lastModifiedDate = formatSecondsSinceEpoch info.lastModified;
-        narHash = info.narHash;
-      } // (if info ? rev then {
-        rev = info.rev;
-        shortRev = builtins.substring 0 7 info.rev;
-      } else {
-      })
-    else if info.type == "path" then
-      { outPath = builtins.path { path = info.path; };
-        narHash = info.narHash;
-      }
-    else if info.type == "tarball" then
-      { outPath =
-          fetchTarball
-            ({ inherit (info) url; }
-             // (if info ? narHash then { sha256 = info.narHash; } else {})
-            );
-      }
-    else if info.type == "gitlab" then
-      { inherit (info) rev narHash lastModified;
-        outPath =
-          fetchTarball
-            ({ url = "https://${info.host or "gitlab.com"}/api/v4/projects/${info.owner}%2F${info.repo}/repository/archive.tar.gz?sha=${info.rev}"; }
-             // (if info ? narHash then { sha256 = info.narHash; } else {})
-            );
-        shortRev = builtins.substring 0 7 info.rev;
-      }
-    else
-      # FIXME: add Mercurial, tarball inputs.
-      throw "flake input has unsupported input type '${info.type}'";
+    callFlake4 = flakeSrc: locks:
+      let
+        flake = import (flakeSrc + "/flake.nix");
 
-  callFlake4 = flakeSrc: locks:
-    let
-      flake = import (flakeSrc + "/flake.nix");
+        inputs = builtins.mapAttrs (n: v:
+          if v.flake or true
+          then callFlake4 (fetchTree (v.locked // v.info)) v.inputs
+          else fetchTree (v.locked // v.info)) locks;
 
-      inputs = builtins.mapAttrs (n: v:
-        if v.flake or true
-        then callFlake4 (fetchTree (v.locked // v.info)) v.inputs
-        else fetchTree (v.locked // v.info)) locks;
+        outputs = flakeSrc // (flake.outputs (inputs // {self = outputs;}));
+      in
+        assert flake.edition == 201909;
+        outputs;
 
-      outputs = flakeSrc // (flake.outputs (inputs // {self = outputs;}));
+    callLocklessFlake = flakeSrc:
+      let
+        flake = import (flakeSrc + "/flake.nix");
+        outputs = flakeSrc // (flake.outputs ({ self = outputs; }));
+      in outputs;
+
+    rootSrc = let
+      # Try to clean the source tree by using fetchGit, if this source
+      # tree is a valid git repository.
+      tryFetchGit = src:
+        if isGit && !isShallow
+        then
+          let res = builtins.fetchGit src;
+          in if res.rev == "0000000000000000000000000000000000000000" then removeAttrs res ["rev" "shortRev"]  else res
+        else { outPath = src; };
+      # NB git worktrees have a file for .git, so we don't check the type of .git
+      isGit = builtins.pathExists (src + "/.git");
+      isShallow = builtins.pathExists (src + "/.git/shallow");
+
     in
-      assert flake.edition == 201909;
-      outputs;
+      { lastModified = 0; lastModifiedDate = formatSecondsSinceEpoch 0; }
+        // (if src ? outPath then src else tryFetchGit src);
 
-  callLocklessFlake = flakeSrc:
-    let
-      flake = import (flakeSrc + "/flake.nix");
-      outputs = flakeSrc // (flake.outputs ({ self = outputs; }));
-    in outputs;
 
-  rootSrc = let
-    # Try to clean the source tree by using fetchGit, if this source
-    # tree is a valid git repository.
-    tryFetchGit = src:
-      if isGit && !isShallow
-      then
-        let res = builtins.fetchGit src;
-        in if res.rev == "0000000000000000000000000000000000000000" then removeAttrs res ["rev" "shortRev"]  else res
-      else { outPath = src; };
-    # NB git worktrees have a file for .git, so we don't check the type of .git
-    isGit = builtins.pathExists (src + "/.git");
-    isShallow = builtins.pathExists (src + "/.git/shallow");
+    nameValuePair = name: value:
+      { inherit name value; };
+    mapAttrs' =
+      # A function, given an attribute's name and value, returns a new `nameValuePair`.
+      f:
+      # Attribute set to map over.
+      set:
+      builtins.listToAttrs (map (attr: f attr set.${attr}) (builtins.attrNames set));
+
+    # Format number of seconds in the Unix epoch as %Y%m%d%H%M%S.
+    formatSecondsSinceEpoch = t:
+      let
+        rem = x: y: x - x / y * y;
+        days = t / 86400;
+        secondsInDay = rem t 86400;
+        hours = secondsInDay / 3600;
+        minutes = (rem secondsInDay 3600) / 60;
+        seconds = rem t 60;
+
+        # Courtesy of https://stackoverflow.com/a/32158604.
+        z = days + 719468;
+        era = (if z >= 0 then z else z - 146096) / 146097;
+        doe = z - era * 146097;
+        yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+        y = yoe + era * 400;
+        doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+        mp = (5 * doy + 2) / 153;
+        d = doy - (153 * mp + 2) / 5 + 1;
+        m = mp + (if mp < 10 then 3 else -9);
+        y' = y + (if m <= 2 then 1 else 0);
+
+        pad = s: if builtins.stringLength s < 2 then "0" + s else s;
+      in "${toString y'}${pad (toString m)}${pad (toString d)}${pad (toString hours)}${pad (toString minutes)}${pad (toString seconds)}";
+
+    rootOverrides =
+      mapAttrs'
+        (input: lockKey: nameValuePair lockKey (impureOverrides.${input} or null))
+        lockFile.nodes.${lockFile.root}.inputs;
+
+    allNodes =
+      builtins.mapAttrs
+        (key: node:
+          let
+            sourceInfo =
+              if key == lockFile.root
+              then rootSrc
+              else
+                if rootOverrides.${key} != null then
+                  { type = "path";
+                    outPath = rootOverrides.${key};
+                    narHash = throw "narHash unimplemented for impureOverride";
+                  }
+                else
+                fetchTree (node.info or {} // removeAttrs node.locked ["dir"]);
+
+            subdir = if key == lockFile.root then "" else node.locked.dir or "";
+
+            flake = import (sourceInfo + (if subdir != "" then "/" else "") + subdir + "/flake.nix");
+
+            inputs = builtins.mapAttrs
+              (inputName: inputSpec: allNodes.${resolveInput inputSpec})
+              (node.inputs or {});
+
+            # Resolve a input spec into a node name. An input spec is
+            # either a node name, or a 'follows' path from the root
+            # node.
+            resolveInput = inputSpec:
+                if builtins.isList inputSpec
+                then getInputByPath lockFile.root inputSpec
+                else inputSpec;
+
+            # Follow an input path (e.g. ["dwarffs" "nixpkgs"]) from the
+            # root node, returning the final node.
+            getInputByPath = nodeName: path:
+              if path == []
+              then nodeName
+              else
+                getInputByPath
+                  # Since this could be a 'follows' input, call resolveInput.
+                  (resolveInput lockFile.nodes.${nodeName}.inputs.${builtins.head path})
+                  (builtins.tail path);
+
+            outputs = flake.outputs (inputs // { self = result; });
+
+            result = outputs // sourceInfo // { inherit inputs; inherit outputs; inherit sourceInfo; };
+          in
+            if node.flake or true then
+              assert builtins.isFunction flake.outputs;
+              result
+            else
+              sourceInfo
+        )
+        lockFile.nodes;
+
+    result =
+      if !(builtins.pathExists lockFilePath)
+      then callLocklessFlake rootSrc
+      else if lockFile.version == 4
+      then callFlake4 rootSrc (lockFile.inputs)
+      else if lockFile.version >= 5 && lockFile.version <= 7
+      then allNodes.${lockFile.root}
+      else throw "lock file '${lockFilePath}' has unsupported version ${toString lockFile.version}";
 
   in
-    { lastModified = 0; lastModifiedDate = formatSecondsSinceEpoch 0; }
-      // (if src ? outPath then src else tryFetchGit src);
+    builtins.mapAttrs (key: attr: overrideWrap' (res: res.${key}) attr)
+      (rec {
+        defaultNix =
+          (builtins.removeAttrs result ["__functor"])
+          // (if result ? defaultPackage.${system} then { default = result.defaultPackage.${system}; } else {})
+          // (if result ? packages.${system}.default then { default = result.packages.${system}.default; } else {});
+        shellNix =
+          defaultNix
+          // (if result ? devShell.${system} then { default = result.devShell.${system}; } else {})
+          // (if result ? devShells.${system}.default then { default = result.devShells.${system}.default; } else {});
+      });
 
-  # Format number of seconds in the Unix epoch as %Y%m%d%H%M%S.
-  formatSecondsSinceEpoch = t:
-    let
-      rem = x: y: x - x / y * y;
-      days = t / 86400;
-      secondsInDay = rem t 86400;
-      hours = secondsInDay / 3600;
-      minutes = (rem secondsInDay 3600) / 60;
-      seconds = rem t 60;
-
-      # Courtesy of https://stackoverflow.com/a/32158604.
-      z = days + 719468;
-      era = (if z >= 0 then z else z - 146096) / 146097;
-      doe = z - era * 146097;
-      yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-      y = yoe + era * 400;
-      doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-      mp = (5 * doy + 2) / 153;
-      d = doy - (153 * mp + 2) / 5 + 1;
-      m = mp + (if mp < 10 then 3 else -9);
-      y' = y + (if m <= 2 then 1 else 0);
-
-      pad = s: if builtins.stringLength s < 2 then "0" + s else s;
-    in "${toString y'}${pad (toString m)}${pad (toString d)}${pad (toString hours)}${pad (toString minutes)}${pad (toString seconds)}";
-
-  allNodes =
-    builtins.mapAttrs
-      (key: node:
-        let
-          sourceInfo =
-            if key == lockFile.root
-            then rootSrc
-            else fetchTree (node.info or {} // removeAttrs node.locked ["dir"]);
-
-          subdir = if key == lockFile.root then "" else node.locked.dir or "";
-
-          flake = import (sourceInfo + (if subdir != "" then "/" else "") + subdir + "/flake.nix");
-
-          inputs = builtins.mapAttrs
-            (inputName: inputSpec: allNodes.${resolveInput inputSpec})
-            (node.inputs or {});
-
-          # Resolve a input spec into a node name. An input spec is
-          # either a node name, or a 'follows' path from the root
-          # node.
-          resolveInput = inputSpec:
-              if builtins.isList inputSpec
-              then getInputByPath lockFile.root inputSpec
-              else inputSpec;
-
-          # Follow an input path (e.g. ["dwarffs" "nixpkgs"]) from the
-          # root node, returning the final node.
-          getInputByPath = nodeName: path:
-            if path == []
-            then nodeName
-            else
-              getInputByPath
-                # Since this could be a 'follows' input, call resolveInput.
-                (resolveInput lockFile.nodes.${nodeName}.inputs.${builtins.head path})
-                (builtins.tail path);
-
-          outputs = flake.outputs (inputs // { self = result; });
-
-          result = outputs // sourceInfo // { inherit inputs; inherit outputs; inherit sourceInfo; };
-        in
-          if node.flake or true then
-            assert builtins.isFunction flake.outputs;
-            result
-          else
-            sourceInfo
-      )
-      lockFile.nodes;
-
-  result =
-    if !(builtins.pathExists lockFilePath)
-    then callLocklessFlake rootSrc
-    else if lockFile.version == 4
-    then callFlake4 rootSrc (lockFile.inputs)
-    else if lockFile.version >= 5 && lockFile.version <= 7
-    then allNodes.${lockFile.root}
-    else throw "lock file '${lockFilePath}' has unsupported version ${toString lockFile.version}";
-
-in
-  rec {
-    defaultNix =
-      (builtins.removeAttrs result ["__functor"])
-      // (if result ? defaultPackage.${system} then { default = result.defaultPackage.${system}; } else {})
-      // (if result ? packages.${system}.default then { default = result.packages.${system}.default; } else {});
-
-    shellNix =
-      defaultNix
-      // (if result ? devShell.${system} then { default = result.devShell.${system}; } else {})
-      // (if result ? devShells.${system}.default then { default = result.devShells.${system}.default; } else {});
-  }
+in makeFlakeCompat {}


### PR DESCRIPTION
This allows the user of this non-flake to have similar functionality to `follows`.

Example (default.nix):

```nix
nix-repl> (import ./.).default
«derivation /nix/store/axgvq22kyb8ymchzq1mjayms4jdl6ni6-ledc-0.1.0.drv»

nix-repl> ((import ./.).overrideInputs { nixpkgs = <nixpkgs>; }).default
«derivation /nix/store/r8zw693hpg91yx6f57hyx1gk4zdiq2lm-ledc-0.1.0.drv»
```

It's currently only able to override our flake's direct inputs. Sorry for the big diff.