### PR TITLE
Apply nix#7207 `_type = "flake";`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -166,7 +166,8 @@ let
 
           outputs = flake.outputs (inputs // { self = result; });
 
-          result = outputs // sourceInfo // { inherit inputs; inherit outputs; inherit sourceInfo; };
+          result = outputs // sourceInfo // { inherit inputs; inherit outputs; inherit sourceInfo; _type = "flake"; };
+
         in
           if node.flake or true then
             assert builtins.isFunction flake.outputs;


### PR DESCRIPTION
https://github.com/NixOS/nix/pull/7207 adds this attribute in order to help identify flake outputs for the purpose of type checking.