### PR TITLE
nix#7796: Ensure that `self.outPath == ./.`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -140,7 +140,9 @@ let
 
           subdir = if key == lockFile.root then "" else node.locked.dir or "";
 
-          flake = import (sourceInfo + (if subdir != "" then "/" else "") + subdir + "/flake.nix");
+          outPath = sourceInfo + ((if subdir == "" then "" else "/") + subdir);
+
+          flake = import (outPath + "/flake.nix");
 
           inputs = builtins.mapAttrs
             (inputName: inputSpec: allNodes.${resolveInput inputSpec})
@@ -167,7 +169,20 @@ let
 
           outputs = flake.outputs (inputs // { self = result; });
 
-          result = outputs // sourceInfo // { inherit inputs; inherit outputs; inherit sourceInfo; _type = "flake"; };
+          result =
+            outputs
+            # We add the sourceInfo attribute for its metadata, as they are
+            # relevant metadata for the flake. However, the outPath of the
+            # sourceInfo does not necessarily match the outPath of the flake,
+            # as the flake may be in a subdirectory of a source.
+            # This is shadowed in the next //
+            // sourceInfo
+            // {
+              # This shadows the sourceInfo.outPath
+              inherit outPath;
+
+              inherit inputs; inherit outputs; inherit sourceInfo; _type = "flake";
+            };
 
         in
           if node.flake or true then


### PR DESCRIPTION
Ported from https://github.com/NixOS/nix/pull/7796
First released in Nix 2.14

Manually tested by evaluating a flake with both a subdir flake and a "regular" input.