### PR TITLE
fix: never attempt to call `builtins.storePath` in pure evaluation mode

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -109,7 +109,7 @@ let
           # Massage `src` into a store path.
           if builtins.isPath src
           then
-            if dirOf (toString src) == builtins.storeDir
+            if builtins ? currentSystem && dirOf (toString src) == builtins.storeDir
             then
               # If it's already a store path, don't copy it again.
               builtins.storePath src


### PR DESCRIPTION
After 5a16547d46553d7bdd1dfc2cf418f5f7d236f6ad, I started getting errors like https://github.com/nix-community/home-manager/issues/2409.

@moduon MT-1075