### PR TITLE
Return all outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ Afterwards, create a `default.nix` file containing the following:
 ```
 
 If you would like a `shell.nix` file, create one containing the above, replacing `defaultNix` with `shellNix`.
+
+You can access any flake output via the `outputs` attribute returned by `flake-compat`, e.g.
+
+```nix
+(import ... { src = ./.; }).outputs.packages.x86_64-linux.default
+```

--- a/default.nix
+++ b/default.nix
@@ -229,6 +229,8 @@ let
 
 in
   rec {
+    outputs = result;
+
     defaultNix =
       (builtins.removeAttrs result ["__functor"])
       // (if result ? defaultPackage.${system} then { default = result.defaultPackage.${system}; } else {})


### PR DESCRIPTION
They were already exposed in `defaultNix` and `shellNix`, but "polluted" by a `default` attribute and probably not very intuitive to find.

Issue #15.