### PR TITLE
Fix non-fetchTree pure-eval use of builtins.path

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -45,7 +45,7 @@ let
       } else {
       })
     else if info.type == "path" then
-      { outPath = builtins.path { path = info.path; };
+      { outPath = builtins.path { path = info.path; sha256 = info.narHash; };
         narHash = info.narHash;
       }
     else if info.type == "tarball" then


### PR DESCRIPTION
This is a rare combination, and it would have been more relevant before https://github.com/edolstra/flake-compat/pull/67, but it is a tested fix nonetheless.
(Specifically, for issues like https://github.com/hercules-ci/flake-parts/issues/252)

builtins.path had `sha256` since its introduction, so no problem there.

This also catches accidental path-based impurities. Flakes are meant to be pure. "path" inputs do ask for trouble, but that doesn't mean we should violate purity.
Also note that `fetchTree` will happily use the `narHash` anyway, so this change makes the behavior more consistent between configurations with and without `fetchTree`.