### PR TITLE
Remove `isShallow` check on root source

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -130,7 +130,7 @@ let
       # tree is a valid git repository.
       tryFetchGit =
         src:
-        if isGit && !isShallow then
+        if isGit then
           let
             res = builtins.fetchGit src;
           in
@@ -160,7 +160,6 @@ let
           };
       # NB git worktrees have a file for .git, so we don't check the type of .git
       isGit = builtins.pathExists (src + "/.git");
-      isShallow = builtins.pathExists (src + "/.git/shallow");
 
     in
     {


### PR DESCRIPTION
This seems to fix #74, by still using `fetchGit` even when the git repo is shallow.

I suspect this means issues similar to #74 can still occur when the flake is not a git repo, perhaps due to an underlying issue with `"${src}"` not correctly copying to store in some scenarios when `nix-instantiate --eval` is used?
