### PR TITLE
Use `builtins.fetchFinalTree` if available

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -18,7 +18,7 @@ let
   lockFile = builtins.fromJSON (builtins.readFile lockFilePath);
 
   fetchTree =
-    builtins.fetchTree or (
+    builtins.fetchFinalTree or builtins.fetchTree or (
       info:
       if info.type == "github" then
         {


### PR DESCRIPTION
Unlike `fetchTree`, this allow inputs to be substituted (since the fetcher won't return any output attributes like `revCount` that weren't in the input attributes).

- See https://github.com/NixOS/nix/pull/14634
- Depends on https://github.com/NixOS/nix/pull/14634

<!-- trigger dpulls maybe? -->