### PR TITLE
feat: add `default` flake template

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ This project was originally at `edolstra/flake-compat` and is now maintained at 
 
 ## Usage
 
+### Automatic setup (template)
+
+To generate both `default.nix` and `shell.nix` automatically, use the default template:
+
+```console
+nix flake init -t github:NixOS/flake-compat
+```
+
+This creates a `default.nix` and `shell.nix` equivalent to the manual setup below.
+
+### Manual setup
+
 To use, add the following to your `flake.nix`:
 
 ```nix

--- a/dev/config.nix
+++ b/dev/config.nix
@@ -13,6 +13,13 @@
     inputs.treefmt-nix.flakeModule
   ];
 
+  flake = {
+    templates.default = {
+      path = ../templates/default;
+      description = "Default files for flake-compat configuration.";
+    };
+  };
+
   # https://flake.parts/options/flake-parts.html#opt-perSystem
   perSystem =
     {

--- a/flake.nix
+++ b/flake.nix
@@ -4,29 +4,31 @@
   outputs =
     { self, ... }:
     let
-      allOutputs = publicOutputs // {
-        # Use explicit inherit, to ensure allOutputs is evaluated without
-        # evaluating devOutputs.
-        inherit (devOutputs) devShells checks formatter;
-      };
-
       # Currently none (`import flake-compat`)
       # TODO: add `lib`.
       publicOutputs = { };
 
-      devOutputs = devInputs.flake-parts.lib.mkFlake {
-        inputs = devInputs;
-      } ./dev/config.nix;
-      devInputs = devDeps // {
-        self = self // {
-          inputs = devInputs;
-        };
-      };
       # TODO: use clean library entrypoint when that's factored out.
       devDeps =
         (import ./default.nix {
           src = ./dev/deps;
         }).defaultNix.inputs;
+
+      devInputs = devDeps // {
+        self = self // {
+          inputs = devInputs;
+        };
+      };
+
+      devOutputs = devInputs.flake-parts.lib.mkFlake {
+        inputs = devInputs;
+      } ./dev/config.nix;
+
+      allOutputs = publicOutputs // {
+        # Use explicit inherit, to ensure allOutputs is evaluated without
+        # evaluating devOutputs.
+        inherit (devOutputs) devShells checks formatter;
+      };
     in
     allOutputs;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
       allOutputs = publicOutputs // {
         # Use explicit inherit, to ensure allOutputs is evaluated without
         # evaluating devOutputs.
-        inherit (devOutputs) devShells checks formatter;
+        inherit (devOutputs) devShells checks formatter templates;
       };
     in
     allOutputs;

--- a/templates/default/default.nix
+++ b/templates/default/default.nix
@@ -1,0 +1,12 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+  fetchTarball {
+    url =
+      lock.nodes.${nodeName}.locked.url
+        or "https://github.com/NixOS/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  }
+) { src = ./.; }).defaultNix

--- a/templates/default/shell.nix
+++ b/templates/default/shell.nix
@@ -1,0 +1,12 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+  fetchTarball {
+    url =
+      lock.nodes.${nodeName}.locked.url
+        or "https://github.com/NixOS/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  }
+) { src = ./.; }).shellNix


### PR DESCRIPTION
This PR:

- Introduce a `default` flake template

If you want to test this, run: `nix flake init -t github:drupol/flake-compat/push-xtnvsxknsvpp`