### PR TITLE
dev: use nix-unit flake-parts module for tests

### DIFF
--- a/dev/config.nix
+++ b/dev/config.nix
@@ -19,7 +19,6 @@
     {
       config,
       pkgs,
-      inputs',
       ...
     }:
     {
@@ -64,8 +63,8 @@
       # Development shell
       devShells.default = pkgs.mkShell {
         nativeBuildInputs = [
+          config.nix-unit.package
           config.treefmt.build.wrapper
-          inputs'.nix-unit.packages.default
         ];
 
         shellHook = ''

--- a/dev/config.nix
+++ b/dev/config.nix
@@ -10,6 +10,7 @@
 
   imports = [
     inputs.git-hooks.flakeModule
+    inputs.nix-unit.modules.flake.default
     inputs.treefmt-nix.flakeModule
   ];
 
@@ -18,6 +19,7 @@
     {
       config,
       pkgs,
+      inputs',
       ...
     }:
     {
@@ -52,34 +54,18 @@
         };
       };
 
-      # Checks
-      checks = {
-        # nix-unit tests for flake-compat
-        nix-unit =
-          pkgs.runCommand "nix-unit-tests"
-            {
-              nativeBuildInputs = [ pkgs.nix-unit ];
-            }
-            ''
-              # Run nix-unit tests on the flake-compat default.nix
-              export HOME=$TMPDIR
-              nix-unit --eval-store "$HOME" ${../.}/tests.nix 2>&1 | tee $out
-
-              # Check if there were any failures
-              if grep -q "FAIL" $out; then
-                echo "Tests failed!"
-                exit 1
-              fi
-
-              echo "All tests passed!"
-            '';
+      # Nix-unit tests
+      # https://flake.parts/options/nix-unit.html
+      nix-unit = {
+        allowNetwork = true;
+        tests = import ../tests.nix;
       };
 
       # Development shell
       devShells.default = pkgs.mkShell {
         nativeBuildInputs = [
           config.treefmt.build.wrapper
-          pkgs.nix-unit
+          inputs'.nix-unit.packages.default
         ];
 
         shellHook = ''

--- a/dev/deps/flake.lock
+++ b/dev/deps/flake.lock
@@ -79,6 +79,54 @@
         "type": "github"
       }
     },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-unit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1737420293,
+        "narHash": "sha256-F1G5ifvqTpJq7fdkT34e/Jy9VCyzd5XfJ9TO8fHhJWE=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "f4158fa080ef4503c8f4c820967d946c2af31ec9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nix-unit": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762774186,
+        "narHash": "sha256-hRADkHjNt41+JUHw2EiSkMaL4owL83g5ZppjYUdF/Dc=",
+        "owner": "nix-community",
+        "repo": "nix-unit",
+        "rev": "1c9ab50554eed0b768f9e5b6f646d63c9673f0f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-unit",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1764950072,
@@ -99,6 +147,7 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "git-hooks": "git-hooks",
+        "nix-unit": "nix-unit",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }

--- a/dev/deps/flake.nix
+++ b/dev/deps/flake.nix
@@ -18,6 +18,16 @@
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    nix-unit = {
+      url = "github:nix-community/nix-unit";
+
+      inputs = {
+        flake-parts.follows = "flake-parts";
+        nixpkgs.follows = "nixpkgs";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
   };
 
   # Input-only flake. Accessed via flake-compat in root flake to extract inputs.

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,12 @@
       allOutputs = publicOutputs // {
         # Use explicit inherit, to ensure allOutputs is evaluated without
         # evaluating devOutputs.
-        inherit (devOutputs) devShells checks formatter;
+        inherit (devOutputs)
+          devShells
+          checks
+          formatter
+          tests
+          ;
       };
 
       # Currently none (`import flake-compat`)


### PR DESCRIPTION
I noticed the project uses flake-parts and nix-unit but runs tests via a manual runCommand check rather the official flake-parts module. Is there a reason for this? Created this PR out of curiosity.

Replace the manual runCommand check with the flake-parts module 
allowNetwork = true is required for fetchTree during evaluationv
^ I think the previous runCommand approach also required network access so this may not be that different.

Relates to https://github.com/NixOS/flake-compat/pull/82